### PR TITLE
Create metric idea issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/metric-idea.md
+++ b/.github/ISSUE_TEMPLATE/metric-idea.md
@@ -1,0 +1,34 @@
+---
+name: Metric Idea
+about: Have an idea for a new metric? Use this template to pitch your idea.
+labels: ['metric idea', '?: needs triage']
+
+---
+
+<!-- Thank you for sharing your metric idea with the Resource Aggregation Working Group! Please use this template to propose your metric idea. This helps our team of reviewers collect important information about your idea and work on a quicker response to your idea. -->
+
+# Metric basics
+<!-- Some basic details about your metric idea. -->
+
+* **Metric title**:
+* **Metric summary** (1-2 sentences):
+* **Why should this metric be created?** (1-2 sentences):
+
+
+# Data collection and measurement
+<!-- Questions to help us think about ways to collect data and how to measure your proposed metric. -->
+
+**Are there existing tools, preferably open source, that could collect this data?** If yes, list them:
+
+**If this metric involves a lot of raw data, what filters would you use to narrow down the metric?** If applicable, describe ways to filter the data into smaller segments:
+
+**Can this metric be visualised? If yes, how would you visualise this metric?** If you have an idea on how this metric should be visualised or displayed so it makes the most sense to a viewer, describe that here:
+
+
+# About you
+<!-- Questions to help us understand your motive and interest in seeing this metric implemented. -->
+
+* **Are you interested in authoring this metric together with the Working Group?**: yes|no
+* **Have you attended a DevRel Foundation Working Group meeting before?**: yes|no
+* **If not, would you consider joining one to discuss your metric idea?**: yes|no
+* **Anything else you would like us to know?**:


### PR DESCRIPTION
This creates an issue template similar to the one used by the [CHAOSS project](https://github.com/chaoss/wg-metrics-development/blob/main/.github/ISSUE_TEMPLATE/01-metric-idea.md) for proposing a DevRel Foundation metric. 